### PR TITLE
Fix Intel driver crashes

### DIFF
--- a/shaders/program/GenSkySH.comp
+++ b/shaders/program/GenSkySH.comp
@@ -104,7 +104,11 @@ void main() {
 		barrier();
 
 		ParallelReduceSum(index, samples);
-		shCoeff = sharedSkySH[0];
+
+		for (uint band = 0u; band < 4u; ++band) {
+			shCoeff[band] = sharedSkySH[0][band];
+		}
+		
 	#endif
 
 	// Store SH coefficients in thread 0

--- a/shaders/program/clouds/Render.comp
+++ b/shaders/program/clouds/Render.comp
@@ -65,7 +65,7 @@ vec3 ScreenToViewVectorRaw(in vec2 screenCoord) {
 	return normalize(vec3(diagonal2(gbufferProjectionInverse) * NDCCoord, gbufferProjectionInverse[3].z));
 }
 
-#ifdef SUBGROUP_OPS
+#if (defined SUBGROUP_OPS && !(defined MC_GL_RENDERER_INTEL))
 	#define clusteredMax subgroupClusteredMax
 #else
 	shared float sharedClusteredMax[256];


### PR DESCRIPTION
In commit 0e3c21e57c75a47322464b141a3283e5e54aea3b, the `GL_KHR_shader_subgroup_clustered` extension was introduced in `shaders/program/clouds/Render.comp` to replace the previous implementation. However, on Windows systems with Intel GPUs, the use of this extension causes crashes—affecting both the JVM and the Intel graphics driver (see https://github.com/HaringPro/Revelation/issues/33 and https://github.com/HaringPro/Revelation/issues/35). An example crash log is provided in: [hs_err_pid22832.log](https://github.com/user-attachments/files/21949547/hs_err_pid22832.log).

This commit resolves the issue by adopting the fallback approach introduced by @moyongxin in https://github.com/HaringPro/Revelation/pull/37 when `MC_GL_RENDERER_INTEL` is defined.

Additionally, this commit fixes a related crash that occurred when `FORCE_DISABLE_SUBGROUP_OPS` was enabled on Intel GPUs, which previously caused the game to exit without any log output. The root cause was an assignment between arrays of the same length:
`shCoeff = sharedSkySH[0];`
This has been corrected by replacing the direct assignment with an element-by-element copy.

The screenshots after the fix (seem to be fine):
(FORCE_DISABLE_SUBGROUP_OPS OFF)
<img width="2880" height="1620" alt="2025-08-23_21 09 21" src="https://github.com/user-attachments/assets/c15dc82c-6188-4b43-adb8-5337b66db11d" />
(FORCE_DISABLE_SUBGROUP_OPS ON)
<img width="2880" height="1620" alt="2025-08-23_21 58 54" src="https://github.com/user-attachments/assets/4ef308dc-2184-4433-b4c2-6fe8d030ac12" />
(The resolution doesn't matter, it's caused by a mod called RenderScale, which change Minecraft's render resolution separately from the HUD elements to improve performance. The mod doesn't affect the test results.)