### PR TITLE
Various Bugfixes: DH/Voxy/Hardcoded Materials

### DIFF
--- a/shaders/program/DH/Terrain.vert
+++ b/shaders/program/DH/Terrain.vert
@@ -40,7 +40,8 @@ uniform vec2 taaJitter;
 void main() {
 	vertColor = gl_Color.rgb;
 
-	lightmap = saturate((gl_MultiTexCoord1.xy - 8.0) * rcp(232.0));
+	lightmap = mat2(gl_TextureMatrix[1]) * gl_MultiTexCoord1.xy + gl_TextureMatrix[1][3].xy;
+	lightmap = saturate((lightmap - 0.03125) * 1.06667);
 
 	materialID = dhMaterialId == DH_BLOCK_LEAVES ? 13u : 1u;
 

--- a/shaders/program/DH/Water.vert
+++ b/shaders/program/DH/Water.vert
@@ -50,7 +50,8 @@ uniform vec2 taaJitter;
 
 //======// Main //================================================================================//
 void main() {
-	lightmap = saturate((gl_MultiTexCoord1.xy - 8.0) * rcp(232.0));
+	lightmap = mat2(gl_TextureMatrix[1]) * gl_MultiTexCoord1.xy + gl_TextureMatrix[1][3].xy;
+	lightmap = saturate((lightmap - 0.03125) * 1.06667);
 	lightmap.x = 0.0;
 
 	vertColor = gl_Color;

--- a/shaders/program/gbuffers/Block.frag
+++ b/shaders/program/gbuffers/Block.frag
@@ -138,6 +138,8 @@ void main() {
 		vec4 specularTex = texture(specular, texCoord);
 		materialOut.z = Packup2x8U(specularTex.xy);
 		materialOut.w = Packup2x8U(specularTex.zw);
+	#else
+		materialOut.zw = uvec2(0);
 	#endif
 
 	normalOut.xy = OctEncodeUnorm(geoNormal);

--- a/shaders/program/gbuffers/Entities.frag
+++ b/shaders/program/gbuffers/Entities.frag
@@ -79,6 +79,8 @@ void main() {
 		vec4 specularTex = texture(specular, texCoord);
 		materialOut.z = Packup2x8U(specularTex.xy);
 		materialOut.w = Packup2x8U(specularTex.zw);
+	#else
+		materialOut.zw = uvec2(0);
 	#endif
 
 	normalOut.xy = OctEncodeUnorm(geoNormal);

--- a/shaders/program/gbuffers/Hand.frag
+++ b/shaders/program/gbuffers/Hand.frag
@@ -67,6 +67,8 @@ void main() {
 		vec4 specularTex = texture(specular, texCoord);
 		materialOut.z = Packup2x8U(specularTex.xy);
 		materialOut.w = Packup2x8U(specularTex.zw);
+	#else
+		materialOut.zw = uvec2(0);
 	#endif
 
 	normalOut.xy = unpackSnorm2x16(normalPack) * 0.5 + 0.5;

--- a/shaders/program/gbuffers/Terrain.frag
+++ b/shaders/program/gbuffers/Terrain.frag
@@ -200,5 +200,7 @@ void main() {
 		vec4 specularTex = ReadTexture(specular);
 		materialOut.z = Packup2x8U(specularTex.xy);
 		materialOut.w = Packup2x8U(specularTex.zw);
+	#else
+		materialOut.zw = uvec2(0);
 	#endif
 }

--- a/shaders/program/voxy/voxy_translucent.glsl
+++ b/shaders/program/voxy/voxy_translucent.glsl
@@ -84,6 +84,6 @@ void voxy_emitFragment(in VoxyFragmentParameters parameters) {
 		waterOut = vec4(waterDepth * rcp255, Packup2x8(encodedWaterNormal), 0.0, 1.0);
 	} else {
 		materialOut.z = Packup2x8U(baseColor.xy);
-		materialOut.w = Packup2x8U(baseColor.zw);
+		materialOut.w = Packup2x8U(vec2(baseColor.z, 0.0));
 	}
 }


### PR DESCRIPTION
What this PR fixed:
- Broken Hardcoded Specular when resourcepack support is disabled;
   - Before vs After:
   
        <img width="320" height="180" alt="2026-03-12_22 37 29" src="https://github.com/user-attachments/assets/31d757fb-7a35-427a-b262-93bc0e2f0e2b" />

        <img width="320" height="180" alt="2026-03-12_22 36 54" src="https://github.com/user-attachments/assets/e0ccdd79-d522-4536-b3bf-47ae924579be" />

- Broken DH Lightmap introduced in de7760d460961a2646a73595393a868f3c3c46ea.
    - Before vs After:
        
        <img width="320" height="180" alt="2026-03-12_22 37 43" src="https://github.com/user-attachments/assets/f6788212-069e-46bb-a621-300847cef0f8" />

        <img width="320" height="180" alt="2026-03-12_22 38 04" src="https://github.com/user-attachments/assets/bf4a3e2a-234a-4854-b6a7-838831f16776" />

- Terrain behind voxy translucent incorrectly emit light when resource pack support is enabled (not sure if the fix is correct).
     - Before vs After:
        
        <img width="320" height="180" alt="2026-03-12_22 47 46" src="https://github.com/user-attachments/assets/a422b72b-19d9-4aa2-bb89-a0cab75ba80a" />

        <img width="320" height="180" alt="2026-03-12_22 46 52" src="https://github.com/user-attachments/assets/29aa7401-6425-44ea-ac05-fda17b5e9286" />
