### PR TITLE
Various LoD Fixes

### DIFF
--- a/shaders/lib/lighting/SSILVB.glsl
+++ b/shaders/lib/lighting/SSILVB.glsl
@@ -180,6 +180,12 @@ vec4 CalculateSSILVB(in vec2 fragCoord, in vec3 viewPos, in vec3 worldNormal, in
 	const float rSliceCount = 1.0 / float(sliceCount);
 	const float rSampleCount = 1.0 / float(sampleCount);
 
+    #if defined LOD_MOD
+        float screenDepthSky = ViewToScreenDepth(ScreenToViewDepthLod(1.0));
+    #else
+        #define screenDepthSky 1.0
+    #endif
+
     float dither = SampleStbnVec1(ivec2(gl_GlobalInvocationID.xy), frameCounter);
 
     vec3 viewDir = normalize(-viewPos);
@@ -238,7 +244,7 @@ vec4 CalculateSSILVB(in vec2 fragCoord, in vec3 viewPos, in vec3 worldNormal, in
                 if (sampleDepth > 1.0 - EPS) sampleDepth = ViewToScreenDepth(ScreenToViewDepthLod(loadDepth0Lod(sampleTexel)));
             #endif
 
-                if (sampleDepth > 1.0 - EPS) continue;
+                if (sampleDepth > screenDepthSky - EPS) continue;
 
                 vec3 samplePos = ScreenToViewPos(vec3(sampleUV, sampleDepth));
 

--- a/shaders/program/IntegrateScene.frag
+++ b/shaders/program/IntegrateScene.frag
@@ -112,6 +112,12 @@ void main() {
 		}
 	#endif
 
+	#if defined LOD_MOD
+    	float screenDepthSky = ViewToScreenDepth(ScreenToViewDepthLod(1.0));
+	#else
+    	#define screenDepthSky 1.0
+	#endif
+
 	uvec4 materialPack = loadMaterialPack(texelPos);
 
 	uint materialID = materialPack.y;
@@ -129,7 +135,7 @@ void main() {
 	vec3 worldPos = mat3(gbufferModelViewInverse) * viewPos;
 	vec3 worldDir = normalize(worldPos);
 
-	if (depth < 1.0) {
+	if (depth < screenDepthSky) {
 		vec4 translucent = ExtractSpecularTex(materialPack);
 		vec3 albedo = sRGBToLinear(translucent.rgb);
 

--- a/shaders/program/VolumetricFog.frag
+++ b/shaders/program/VolumetricFog.frag
@@ -60,6 +60,13 @@ void main() {
 	vec3 screenPos = vec3(screenCoord, loadDepth0(texelPos));
 
 	vec3 viewPos = ScreenToViewPosRaw(screenPos);
+
+	#if defined LOD_MOD
+        float screenDepthSky = ViewToScreenDepth(ScreenToViewDepthLod(1.0));
+    #else
+        #define screenDepthSky 1.0
+    #endif
+
 	#if defined LOD_MOD
 		if (screenPos.z > 1.0 - EPS) {
 			screenPos.z = loadDepth0Lod(texelPos);
@@ -75,7 +82,7 @@ void main() {
 
 	#ifdef VOLUMETRIC_FOG
 		if (isEyeInWater == 0) {
-			volFogData = RaymarchAtmosphericFog(gbufferModelViewInverse[3].xyz, worldPos, dither, screenPos.z > 1.0 - EPS, VF_MAX_SAMPLES);
+			volFogData = RaymarchAtmosphericFog(gbufferModelViewInverse[3].xyz, worldPos, dither, screenPos.z > screenDepthSky - EPS, VF_MAX_SAMPLES);
 		}
 	#endif
 	#ifdef UW_VOLUMETRIC_FOG

--- a/shaders/program/diffuse/Accumulate.frag
+++ b/shaders/program/diffuse/Accumulate.frag
@@ -134,11 +134,18 @@ void main() {
 
     float depth = loadDepth0(renderTexel);
     bool terrainCheck = min(GetClosestDepthN(renderTexel), depth) < 1.0;
+    
+    #if defined LOD_MOD
+        float screenDepthSky = ViewToScreenDepth(ScreenToViewDepthLod(1.0));
+    #else
+        #define screenDepthSky 1.0
+    #endif
+
     #if defined LOD_MOD
         bool lodMask = !terrainCheck;
         if (lodMask) {
             depth = loadDepth0Lod(renderTexel);
-            terrainCheck = depth < 1.0;
+            terrainCheck = depth < screenDepthSky;
         }
     #endif
 

--- a/shaders/program/diffuse/DiffuseIndirect.comp
+++ b/shaders/program/diffuse/DiffuseIndirect.comp
@@ -61,11 +61,18 @@ void main() {
     ivec2 renderTexel = texelPos * 2 + checkerboardOffset2x2[frameCounter & 3u];
 	float depth = loadDepth0(renderTexel);
 	bool terrainCheck = min(GetClosestDepthN(renderTexel), depth) < 1.0;
+
+	#if defined LOD_MOD
+        float screenDepthSky = ViewToScreenDepth(ScreenToViewDepthLod(1.0));
+    #else
+        #define screenDepthSky 1.0
+    #endif
+
 	#if defined LOD_MOD
         bool lodMask = !terrainCheck;
 		if (lodMask) {
 			depth = loadDepth0Lod(renderTexel);
-			terrainCheck = depth < 1.0;
+			terrainCheck = depth < screenDepthSky;
 		}
 	#endif
 

--- a/shaders/program/voxy/Blit.comp
+++ b/shaders/program/voxy/Blit.comp
@@ -28,11 +28,19 @@ writeonly uniform image2D colorimg8;
 uniform usampler2D colortex16;
 uniform sampler2D colortex17;
 
+#include "/lib/universal/Uniform.glsl"
+
+//======// Functions //================================================================================//
+
+#include "/lib/universal/Transform.glsl"
+
 //======// Main //================================================================================//
 void main() {
 	ivec2 texelPos = ivec2(gl_GlobalInvocationID.xy);
 
 	uvec4 materialData = texelFetch(colortex16, texelPos, 0);
+
+	if (loadDepth0(texelPos) < 1.0 - EPS && loadDepth0(texelPos) < ViewToScreenDepth(ScreenToViewDepthLod(loadDepth0Lod(texelPos)))) return;
 
     if (materialData.y > 0u) {
 		imageStore(colorimg7, texelPos, materialData);


### PR DESCRIPTION
- Fixed Voxy transparent being written on top of various geometries like hand/beacon beam
    - Before vs After:
      <img width="320" height="180" alt="2026-04-09_21 30 25" src="https://github.com/user-attachments/assets/afd5129c-37c1-48b8-8139-abab45cd4423" />  <img width="320" height="180" alt="2026-04-09_21 31 11" src="https://github.com/user-attachments/assets/055a0d0f-91e7-4653-93d2-61afd2787e3b" />
- Fixed SSILVB (and some other techniques) incorrectly uses vanilla far plane instead of LoD ones, causing SSILVB missing when distance > 512
    - Before vs After:
      <img width="320" height="180" alt="2026-04-09_21 41 52" src="https://github.com/user-attachments/assets/c24507ef-3a49-4694-b182-63af15b3c0cf" /> <img width="320" height="180" alt="2026-04-09_21 42 00" src="https://github.com/user-attachments/assets/750cdb16-7b25-45dc-9cb8-e5b2ac77612c" />

