### PR TITLE
Fixed error when SR is not installed

### DIFF
--- a/shaders/program/post/Final.frag
+++ b/shaders/program/post/Final.frag
@@ -41,7 +41,7 @@ out vec3 finalOut;
 // https://github.com/GPUOpen-Effects/FidelityFX-CAS
 
 vec3 FFXCasFilter(in ivec2 texel, in float sharpness) {
-    #if UPSCALE_MODE == 0 && SR_DISABLE
+    #if UPSCALE_MODE == 0 && (SR_DISABLE || !SR_INSTALLED)
         texel = scaleTexelPos(texel);
     #endif
 

--- a/shaders/program/post/Grade.frag
+++ b/shaders/program/post/Grade.frag
@@ -61,7 +61,7 @@ out vec3 color; // Tonemapped output
 #include "/lib/universal/Random.glsl"
 
 void CombineBloomAndFog(inout vec3 scene, ivec2 texel, float exposure) {
-    #if SR_DISABLE
+    #if (SR_DISABLE || !SR_INSTALLED)
         vec2 screenCoord = texelToUvScaled(texel);
     #else
         vec2 screenCoord = texelToUv(texel);
@@ -174,7 +174,7 @@ void main() {
 	#else
 		float exposure = exposure.value;
 	#endif
-    #if SR_DISABLE
+    #if (SR_DISABLE || !SR_INSTALLED)
 	    #ifdef MOTION_BLUR
 	    	color = texelFetch(colortex0, texelPos, 0).rgb;
 	    #else
@@ -222,7 +222,7 @@ void main() {
 
 	// Vignetting
 	#ifdef VIGNETTE_ENABLED
-        #if SR_DISABLE
+        #if (SR_DISABLE || !SR_INSTALLED)
 		    vec2 ndcCoord = texelToUvScaled(texelPos) * 2.0 - 1.0;
         #else
             vec2 ndcCoord = texelToUv(texelPos) * 2.0 - 1.0;
@@ -249,7 +249,7 @@ void main() {
 	#ifdef DEBUG_TONE_MAPPING_PLOT
 		const float scale = 1.5;
 
-        #if SR_DISABLE
+        #if (SR_DISABLE || !SR_INSTALLED)
         vec2 uv = texelToUvScaled(texelPos) * vec2(aspectRatio, 1.0) * scale;
         #else
         vec2 uv = texelToUv(texelPos) * vec2(aspectRatio, 1.0) * scale;

--- a/shaders/program/post/TemporalAA.frag
+++ b/shaders/program/post/TemporalAA.frag
@@ -171,7 +171,7 @@ void main() {
             motionVectorOut = motionVector;
 		#endif
 
-		#if defined(TAA_ENABLED) && SR_DISABLE
+		#if defined(TAA_ENABLED) && (SR_DISABLE || !SR_INSTALLED)
 			temporalOut = TemporalReprojection(screenCoord, motionVector);
 		#else
 			temporalOut = vec4(loadSceneMain(screenTexel), 1.0);


### PR DESCRIPTION
The reason is simple: `SR_DISABLE` is not present when SR is not installed, causing TemporalReprojection and builtin scaling to be skipped when SR is not present, breaking rendering.