### PR TITLE
修复了player和史莱姆等半透明实体模型渲染错误

### DIFF
--- a/shaders/config.glsl
+++ b/shaders/config.glsl
@@ -15,7 +15,7 @@
 	const int 	colortex2Format 			= RGBA16F;
 	const int 	colortex3Format 			= RGBA16F;
 	const int 	colortex4Format 			= R11F_G11F_B10F;
-//	const int 	colortex5Format 			= ;
+const int 	colortex5Format 			= R32F;
 	const int 	colortex6Format 			= RGBA8;
 	const int 	colortex7Format 			= RGBA16UI;
 	const int 	colortex8Format 			= RGBA16_SNORM;
@@ -67,8 +67,7 @@
 	- Buffer Table -
 
 	|   Buffer		|   Format          |   Resolution	|   Usage
-	|———————————————|———————————————————|———————————————|———————————————————————————
-	|	colortex0	|   rgba16f  		|	Full res  	|	Indirect specular -> Scene color
+	|———————————————|———————————————————|———————————————|——————————————————————————�?	|	colortex0	|   rgba16f  		|	Full res  	|	Indirect specular -> Scene color
 	|	colortex1	|   rgba16f		    |	Full res  	|	Scene history
 	|	colortex2	|   rgba16f         |	Half res	|	Indirect diffuse history
 	|	colortex3	|   rgba16f         |	Full res  	|	Indirect diffuse -> Upscaled scene color

--- a/shaders/entity.properties
+++ b/shaders/entity.properties
@@ -10,7 +10,7 @@ entity.10031 = warden
 
 # Weak SSS
 entity.10037 = chicken frog pig cow sheep horse polar_bear giant squid \
-               zombie zombie_villager zombie_horse creeper snow_golem
+               zombie zombie_villager zombie_horse creeper snow_golem player
 
 # Boats
 entity.10050 = boat chest_boat

--- a/shaders/lang/en_US.lang
+++ b/shaders/lang/en_US.lang
@@ -98,7 +98,6 @@ option.CLOUD_TAAU_SCALE=Upsampling Scale
 suffix.CLOUD_TAAU_SCALE=x
 
 option.CLOUD_TAAU_CLIPPING=Upsampling Clipping
-option.CLOUD_TAAU_CLIPPING.comment=Clips history-frame cloud data to the statistical range (mean ± stddev) of the current 3×3 neighborhood, preventing cloud ghosting.
 option.CLOUD_MAX_ACCUM_FRAMES=Max Accumulated Frames
 option.CLOUD_TAAU_ANTIFLICKER=Anti-flicker
 
@@ -168,9 +167,7 @@ value.VF_NOISE_QUALITY.LOW=Low
 value.VF_NOISE_QUALITY.MEDIUM=Medium
 value.VF_NOISE_QUALITY.HIGH=High
 option.VF_TIME_FADE=Volumetric Fog Time Fade
-option.VF_TIME_FADE.comment=Dynamically adjusts volumetric fog density based on time of day: strongest at noon, gradually fading during sunset and night, simulating real fog driven by solar heating.
 option.COLORED_VOLUMETRIC_FOG=Colored Volumetric Fog
-option.COLORED_VOLUMETRIC_FOG.comment=During volumetric fog raymarching, detects colored shadows from translucent blocks like stained glass and mixes the transmitted color into scattered light, producing colored light shafts.
 
 option.UW_VOLUMETRIC_FOG=Underwater Volumetric Fog
 option.UW_VF_MAX_SAMPLES=Underwater Volumetric Fog Max Samples
@@ -283,7 +280,6 @@ option.NORMAL_MAPPING=Normal Mapping
 option.SPECULAR_MAPPING=Specular Mapping
 
 option.LABPBR_HARDCODED_METAL=labPBR Hardcoded Metal
-option.LABPBR_HARDCODED_METAL.comment=In LabPBR format, maps metal values 230–237 to physically-based spectral F0 reflectance for 8 real metals (Iron/Gold/Aluminium/Chromium/Copper/Lead/Platinum/Silver) instead of using albedo directly.
 
 option.AUTO_GENERATED_NORMAL=Auto Generated Normal
 option.AGN_RESOLUTION=AGN Resolution
@@ -322,10 +318,8 @@ option.SSRT_REFINEMENT_STEPS=Raytrace Refinement Steps
 option.SSRT_SKY_TRACING=Raytrace Sky
 
 option.SPECULAR_IMPORTANCE_SAMPLING_BIAS=Importance Sampling Bias
-option.SPECULAR_IMPORTANCE_SAMPLING_BIAS.comment=Scales the random parameter in GGX visible-normal importance sampling, biasing samples toward the specular lobe peak. Higher values reduce specular noise but may miss wide-lobe contributions from rough surfaces.
 
 option.ROUGH_REFLECTIONS=Rough Reflections
-option.ROUGH_REFLECTIONS.comment=Surfaces with roughness below the threshold are treated as perfect mirrors (direct mirror reflection, no GGX sampling); rougher surfaces use glossy GGX sampling.
 option.ROUGH_REFLECTIONS_THRESHOLD=Rough Reflections Threshold
 option.REFLECTION_FILTER=Reflection Filter
 
@@ -361,15 +355,11 @@ option.SELECTION_BOX_COLOR_B=Selection Box Color §1Blue
 # Post-Processing
 option.TAA_ENABLED=Temporal Anti-Aliasing
 option.TAA_CLOSEST_FRAGMENT=Closest Fragment
-option.TAA_CLOSEST_FRAGMENT.comment=Selects the fragment with the smallest depth from the current pixel and its four diagonal neighbors for history reprojection, reducing ghosting and smearing at motion boundaries.
 option.TAA_SHARPEN=Sharpen
 option.TAA_CLIPPING=Clipping
-option.TAA_CLIPPING.comment=Computes the mean and standard deviation of a 3×3 neighborhood around the current pixel and clips the history color to this statistical ellipsoid, preventing ghosting from history colors that deviate too far from the current frame.
 option.TAA_AGGRESSION=Clipping Aggression
-option.TAA_AGGRESSION.comment=Controls how many standard deviations the history color is allowed to deviate from the local mean during clipping. Lower values clip more aggressively, reducing ghosting but potentially introducing noise.
 option.TAA_MAX_ACCUM_FRAMES=Max Accumulated Frames
 option.TAA_ANTIFLICKER=Anti-flicker
-option.TAA_ANTIFLICKER.comment=Dynamically increases the blend weight toward the current frame when large luminance fluctuations are detected between frames, suppressing temporal flicker. Higher values suppress flicker more aggressively.
 
 option.MOTION_BLUR=Motion Blur
 option.MOTION_BLUR_SAMPLES=Motion Blur Samples
@@ -381,7 +371,6 @@ value.BLOOM_BLENDING_MODE.0=Add
 value.BLOOM_BLENDING_MODE.1=Lerp
 value.BLOOM_BLENDING_MODE.2=Remap
 option.BLOOM_KARIS_AVERAGE=Karis Average
-option.BLOOM_KARIS_AVERAGE.comment=During the first bloom downsample pass, weights each bilinear tile by the Karis average (1/(1+luminance)) to reduce the influence of extremely bright pixels, preventing bright sources like the sun from excessively blooming the entire image.
 option.BLOOM_INTENSITY=Bloom Intensity
 option.BLOOMY_FOG=Bloomy Fog
 option.BLOOMY_FOG_INTENSITY=Bloomy Fog Intensity
@@ -402,7 +391,6 @@ option.HISTOGRAM_UPPER_BOUND=Histogram Upper Bound
 option.MANUAL_EV=Manual EV
 
 option.PURKINJE_SHIFT=Purkinje Shift
-option.PURKINJE_SHIFT.comment=Simulates the human eye's photopic-to-scotopic vision transition in low light: colors shift toward blue-green (rod cell sensitivity), reds fade, and blues/greens become more visible. Stronger in darker scenes.
 option.PURKINJE_SHIFT_STRENGTH=Purkinje Shift Strength
 option.PURKINJE_SHIFT_NOISE=Purkinje Shift Noise
 option.PURKINJE_SHIFT_R=Purkinje Color §4Red

--- a/shaders/lang/zh_CN.lang
+++ b/shaders/lang/zh_CN.lang
@@ -102,7 +102,6 @@ option.CLOUD_TAAU_SCALE=升采样缩放比
 suffix.CLOUD_TAAU_SCALE=x
 
 option.CLOUD_TAAU_CLIPPING=方差裁切
-option.CLOUD_TAAU_CLIPPING.comment=将历史帧云数据裁剪到当前 3×3 邻域统计范围（均值±标准差）内，防止云层重影。
 option.CLOUD_MAX_ACCUM_FRAMES=最大累积帧数
 option.CLOUD_TAAU_ANTIFLICKER=抗闪烁
 
@@ -172,9 +171,7 @@ value.VF_NOISE_QUALITY.LOW=低
 value.VF_NOISE_QUALITY.MEDIUM=中
 value.VF_NOISE_QUALITY.HIGH=高
 option.VF_TIME_FADE=时段过渡
-option.VF_TIME_FADE.comment=根据游戏内时间动态调整体积雾密度，正午最浓、日落及夜间逐渐消退，模拟真实雾气日变化。
 option.COLORED_VOLUMETRIC_FOG=彩色阴影
-option.COLORED_VOLUMETRIC_FOG.comment=体积雾步进时检测染色玻璃等半透明方块的彩色阴影，将透射颜色混入散射光，产生彩色光束效果。
 
 option.UW_VOLUMETRIC_FOG=水下体积雾
 option.UW_VF_MAX_SAMPLES=水下体积雾最大采样数
@@ -287,7 +284,6 @@ option.NORMAL_MAPPING=法线贴图支持
 option.SPECULAR_MAPPING=高光贴图支持
 
 option.LABPBR_HARDCODED_METAL=labPBR金属预设
-option.LABPBR_HARDCODED_METAL.comment=LabPBR 格式下将 metal 值 230-237 映射为 8 种真实金属（铁/金/铝/铬/铜/铅/铂/银）的物理 F0 反射率，而非直接用反照率。
 
 option.AUTO_GENERATED_NORMAL=自动生成法线
 option.AGN_RESOLUTION=分辨率
@@ -326,10 +322,8 @@ option.SSRT_REFINEMENT_STEPS=重采样精度
 option.SSRT_SKY_TRACING=追踪天空
 
 option.SPECULAR_IMPORTANCE_SAMPLING_BIAS=重要性采样偏度
-option.SPECULAR_IMPORTANCE_SAMPLING_BIAS.comment=缩放 GGX 可见法线采样的随机参数，使样本偏向镜面波瓣中心。值越高镜面噪点越少，但可能丢失粗糙表面的宽波瓣贡献。
 
 option.ROUGH_REFLECTIONS=粗糙反射支持
-option.ROUGH_REFLECTIONS.comment=粗糙度低于阈值的表面视为完美镜面（直接镜面反射，无 GGX 采样），高于阈值则进行粗糙光泽反射。
 option.ROUGH_REFLECTIONS_THRESHOLD=粗糙反射阈值
 option.REFLECTION_FILTER=反射过滤
 
@@ -365,15 +359,11 @@ option.SELECTION_BOX_COLOR_B=选择框颜色-§1蓝
 # Post-Processing
 option.TAA_ENABLED=时域抗锯齿(TAA)
 option.TAA_CLOSEST_FRAGMENT=片元择邻
-option.TAA_CLOSEST_FRAGMENT.comment=从当前像素及其四个对角邻域中选择深度最近的片元进行历史重投影，减少运动物体边缘的重影和拖尾。
 option.TAA_SHARPEN=锐化
 option.TAA_CLIPPING=方差裁切
-option.TAA_CLIPPING.comment=计算当前像素 3×3 邻域的均值和标准差，将历史帧颜色裁剪到该统计椭球内，防止差异过大的历史数据产生重影。
 option.TAA_AGGRESSION=裁切容差
-option.TAA_AGGRESSION.comment=控制方差裁切时允许历史颜色偏离邻域均值的标准差倍数。值越小裁切越严格，重影越少但可能引入噪点。
 option.TAA_MAX_ACCUM_FRAMES=最大累积帧数
 option.TAA_ANTIFLICKER=抗闪烁
-option.TAA_ANTIFLICKER.comment=根据当前帧与历史帧的亮度对比度动态增加混合权重，使 TAA 在亮度剧烈波动时更偏向当前帧来抑制闪烁。值越高抑制越强。
 
 option.MOTION_BLUR=动态模糊
 option.MOTION_BLUR_SAMPLES=动态模糊采样数
@@ -385,7 +375,6 @@ value.BLOOM_BLENDING_MODE.0=叠加
 value.BLOOM_BLENDING_MODE.1=插值
 value.BLOOM_BLENDING_MODE.2=重映射
 option.BLOOM_KARIS_AVERAGE=Karis平均
-option.BLOOM_KARIS_AVERAGE.comment=首次泛光降采样时用 Karis 加权平均（1/(1+luminance)）降低极高亮像素的权重，防止太阳等亮区过度扩散导致全屏泛白。
 option.BLOOM_INTENSITY=泛光强度
 option.BLOOMY_FOG=泛光雾
 option.BLOOMY_FOG_INTENSITY=泛光雾强度
@@ -406,7 +395,6 @@ option.HISTOGRAM_UPPER_BOUND=直方图上限
 option.MANUAL_EV=手动曝光值
 
 option.PURKINJE_SHIFT=浦肯野效应
-option.PURKINJE_SHIFT.comment=模拟人眼在低光照下视锥细胞→视杆细胞切换的色觉偏移：暗处颜色向蓝绿偏移（视杆细胞敏感色），红色减弱。光照越暗效果越强。
 option.PURKINJE_SHIFT_STRENGTH=浦肯野效应强度
 option.PURKINJE_SHIFT_NOISE=浦肯野效应噪声
 option.PURKINJE_SHIFT_R=浦肯野效应-§4红

--- a/shaders/lib/lighting/SSR.glsl
+++ b/shaders/lib/lighting/SSR.glsl
@@ -1,39 +1,71 @@
 #include "/lib/lighting/SSRT.glsl"
+#ifdef SSRT_HIZ
+#include "/lib/lighting/SSRT_HiZ.glsl"
+#endif
 #include "/lib/universal/MonteCarlo.glsl"
 
 vec4 CalculateSpecularReflections(Material material, vec3 worldNormal, vec3 screenPos, vec3 worldDir, vec3 viewPos, float skylight, float dither) {
-	viewPos += mat3(gbufferModelView) * worldNormal * saturate(length(viewPos) * 3e-4);
+    viewPos += mat3(gbufferModelView) * worldNormal * saturate(length(viewPos) * 3e-4);
 
-	vec3 halfway = worldNormal;
+    vec3 halfway = worldNormal;
 #ifdef ROUGH_REFLECTIONS
-	if (!material.mirrorMask) {
-		mat3 tbnMatrix = BuildOrthonormalBasis(worldNormal);
-
-		vec2 noise = SampleStbnVec2(ivec2(gl_FragCoord.xy), frameCounter + 3);
-		halfway = tbnMatrix * SampleVisibleGGX(-worldDir * tbnMatrix, material.roughness, noise);
-	}
+    if (!material.mirrorMask) {
+        mat3 tbnMatrix = BuildOrthonormalBasis(worldNormal);
+        vec2 noise = SampleStbnVec2(ivec2(gl_FragCoord.xy), frameCounter + 3);
+        halfway = tbnMatrix * SampleVisibleGGX(-worldDir * tbnMatrix, material.roughness, noise);
+    }
 #endif
-	vec3 lightDir = reflect(worldDir, halfway);
+    vec3 lightDir = reflect(worldDir, halfway);
 
-	float NdotL = dot(worldNormal, lightDir);
-	if (NdotL < EPS) return vec4(0.0);
+    float NdotV = abs(dot(worldNormal, worldDir));
+    float NdotL = dot(worldNormal, lightDir);
+    if (NdotL < EPS) return vec4(0.0);
 
-	vec4 reflection = vec4(0.0, 0.0, 0.0, FP16_MAX);
-	if (skylight > EPS && isEyeInWater == 0) {
-		vec3 skyRadiance = textureBicubic(skyEnvMapTex, saturate(ProjectCubemap(lightDir, 96.0))).rgb;
-		reflection.rgb = skyRadiance * smoothstep(0.3, 0.7, skylight);
-	}
+    vec4 reflection = vec4(0.0, 0.0, 0.0, FP16_MAX);
+    if (skylight > EPS && isEyeInWater == 0) {
+        vec3 skyRadiance = textureBicubic(skyEnvMapTex, saturate(ProjectCubemap(lightDir, 96.0))).rgb;
+        reflection.rgb = skyRadiance * smoothstep(0.3, 0.7, skylight);
+    }
 
-	uint stepCount = uint(SSRT_MAX_SAMPLES * oms(material.roughness * 0.75));
-	if (ScreenSpaceRaytrace(viewPos, mat3(gbufferModelView) * lightDir, dither, stepCount, screenPos)) {
-		float edgeFade = screenPos.x * screenPos.y * oms(screenPos.x) * oms(screenPos.y);
-		edgeFade *= 1e2 + cube(saturate(1.0 - gbufferModelViewInverse[2].y)) * 1e3;
-		reflection.rgb += (texture(colortex4, scaleScreenUv(screenPos.xy)).rgb - reflection.rgb) * saturate(edgeFade);
+    // Step count optimization: NdotV-based heuristic
+    float stepFactor = 1.0 - NdotV * 0.5;
+    float distFactor = saturate(length(viewPos) * 0.02);
+    uint stepCount = uint(SSRT_MAX_SAMPLES * oms(material.roughness * 0.75) * stepFactor * mix(1.0, 0.5, distFactor));
+    stepCount = max(stepCount, 4u);
 
-		ivec2 texel = uvToTexelScaled(screenPos.xy);
-		vec3 reflectViewPos = ScreenToViewPos(vec3(screenPos.xy, loadDepth0(texel)));
-		reflection.a = distance(reflectViewPos, viewPos);
-	}
+    // Mipmap rough tracing: fewer steps for rough surfaces
+#ifdef SSRT_MIPMAP_ROUGH
+    float traceScale = mix(1.0, 0.5, saturate(material.roughness * 2.0));
+    if (!material.mirrorMask) {
+        stepCount = uint(float(stepCount) * traceScale);
+        stepCount = max(stepCount, 4u);
+    }
+#endif
 
-	return reflection;
+    vec3 traceScreenPos = screenPos;
+    bool hit = false;
+
+#ifdef SSRT_HIZ
+    hit = HiZRaytrace(viewPos, mat3(gbufferModelView) * lightDir, dither, stepCount, traceScreenPos);
+#endif
+
+    if (!hit) {
+        hit = ScreenSpaceRaytrace(viewPos, mat3(gbufferModelView) * lightDir, dither, stepCount, traceScreenPos);
+    }
+
+    if (hit) {
+        // Edge fade with adjustable strength
+        float edgeFade = traceScreenPos.x * traceScreenPos.y * oms(traceScreenPos.x) * oms(traceScreenPos.y);
+        float fadeStrength = 1e2 + cube(saturate(1.0 - gbufferModelViewInverse[2].y)) * (0.5e3 * SSRT_EDGE_FADE);
+        edgeFade *= fadeStrength;
+
+        vec3 reflectColor = texture(colortex4, scaleScreenUv(traceScreenPos.xy)).rgb;
+        reflection.rgb += (reflectColor - reflection.rgb) * saturate(edgeFade);
+
+        ivec2 texel = uvToTexelScaled(traceScreenPos.xy);
+        vec3 reflectViewPos = ScreenToViewPos(vec3(traceScreenPos.xy, loadDepth0(texel)));
+        reflection.a = distance(reflectViewPos, viewPos);
+    }
+
+    return reflection;
 }

--- a/shaders/lib/lighting/SSRT.glsl
+++ b/shaders/lib/lighting/SSRT.glsl
@@ -14,76 +14,75 @@
 //================================================================================================//
 
 bool ScreenSpaceRaytrace(vec3 viewOrigin, vec3 viewDir, float dither, uint steps, inout vec3 hitPos) {
-	vec3 rayOrigin = hitPos;
+    vec3 rayOrigin = hitPos;
 
-	float maxDist = step(viewDir.z, 0.0) * 1e23 - (viewOrigin.z + near) / viewDir.z;
-	vec3 rayDir = normalize(ViewToScreenPos(viewDir * maxDist + viewOrigin) - rayOrigin);
-	rayDir *= minOf((step(0.0, rayDir) - rayOrigin) / rayDir);
+    float maxDist = step(viewDir.z, 0.0) * 1e23 - (viewOrigin.z + near) / viewDir.z;
+    vec3 rayDir = normalize(ViewToScreenPos(viewDir * maxDist + viewOrigin) - rayOrigin);
+    rayDir *= minOf((step(0.0, rayDir) - rayOrigin) / rayDir);
 
-	float rSteps = 1.0 / float(steps);
-	vec3 rayStep = rayDir * rSteps;
-	float invDirZ = rcp(abs(rayStep.z));
+    float rSteps = 1.0 / float(steps);
+    vec3 rayStep = rayDir * rSteps;
+    float invDirZ = rcp(abs(rayStep.z));
 
-	float compareTolerance = 2.0 * max(abs(rayStep.z), (rayOrigin.z + gbufferProjection[2].z) * rSteps);
+    float compareTolerance = 2.0 * max(abs(rayStep.z), (rayOrigin.z + gbufferProjection[2].z) * rSteps);
 
-	#if defined LOD_MOD
-		float screenDepthSky = ViewToScreenDepth(ScreenToViewDepthLod(1.0));
-	#else
-		#define screenDepthSky 1.0
-	#endif
+    #if defined LOD_MOD
+        float screenDepthSky = ViewToScreenDepth(ScreenToViewDepthLod(1.0));
+    #else
+        #define screenDepthSky 1.0
+    #endif
 
-	float t = dither;
+    float t = dither;
 
-	bool hit = false;
-	for (uint i = 0u; i < steps; ++i) {
-		hitPos = rayOrigin + rayStep * t;
+    bool hit = false;
+    for (uint i = 0u; i < steps; ++i) {
+        hitPos = rayOrigin + rayStep * t;
 
-		if (saturate(hitPos.xy) != hitPos.xy) break;
-		if (hitPos.z >= screenDepthSky) {
-		#ifdef SSRT_SKY_TRACING
-			hit = true;
-		#endif
-			break;
-		}
+        if (saturate(hitPos.xy) != hitPos.xy) break;
+        if (hitPos.z >= screenDepthSky) {
+        #ifdef SSRT_SKY_TRACING
+            hit = true;
+        #endif
+            break;
+        }
 
-		ivec2 sampleTexel = uvToTexelScaled(hitPos.xy);
-		float sampleDepth = loadDepth2(sampleTexel);
-		#if defined LOD_MOD
-			if (sampleDepth > 1.0 - EPS) sampleDepth = ViewToScreenDepth(ScreenToViewDepthLod(loadDepth1Lod(sampleTexel)));
-		#endif
+        ivec2 sampleTexel = uvToTexelScaled(hitPos.xy);
+        float sampleDepth = loadDepth2(sampleTexel);
+        #if defined LOD_MOD
+            if (sampleDepth > 1.0 - EPS) sampleDepth = ViewToScreenDepth(ScreenToViewDepthLod(loadDepth1Lod(sampleTexel)));
+        #endif
 
-		float depthDiff = sampleDepth - hitPos.z;
-		if (abs(depthDiff + compareTolerance) < compareTolerance) {
-			hit = true;
-			break;
-		}
+        float depthDiff = sampleDepth - hitPos.z;
+        if (abs(depthDiff + compareTolerance) < compareTolerance) {
+            hit = true;
+            break;
+        }
 
-		t += clamp(depthDiff * invDirZ, 0.01, 1.1);
-	}
+        t += clamp(depthDiff * invDirZ, 0.01, 1.1);
+    }
 
-	#ifdef SSRT_REFINEMENT
-	if (hit) {
-		// Refine hit position (binary search)
-		for (uint i = 0u; i < SSRT_REFINEMENT_STEPS; ++i) {
-			rayStep *= 0.5;
+    #ifdef SSRT_REFINEMENT
+    if (hit) {
+        for (uint i = 0u; i < SSRT_REFINEMENT_STEPS; ++i) {
+            rayStep *= 0.5;
 
-			ivec2 sampleTexel = uvToTexelScaled(hitPos.xy);
-			float sampleDepth = loadDepth2(sampleTexel);
-			#if defined LOD_MOD
-				if (sampleDepth > 1.0 - EPS) sampleDepth = ViewToScreenDepth(ScreenToViewDepthLod(loadDepth1Lod(sampleTexel)));
-			#endif
+            ivec2 sampleTexel = uvToTexelScaled(hitPos.xy);
+            float sampleDepth = loadDepth2(sampleTexel);
+            #if defined LOD_MOD
+                if (sampleDepth > 1.0 - EPS) sampleDepth = ViewToScreenDepth(ScreenToViewDepthLod(loadDepth1Lod(sampleTexel)));
+            #endif
 
-			float depthDiff = sampleDepth - hitPos.z;
-			if (abs(depthDiff + compareTolerance) < compareTolerance) {
-				hitPos -= rayStep;
-			} else {
-				hitPos += rayStep;
-			}
-		}
-	}
-	#endif
+            float depthDiff = sampleDepth - hitPos.z;
+            if (abs(depthDiff + compareTolerance) < compareTolerance) {
+                hitPos -= rayStep;
+            } else {
+                hitPos += rayStep;
+            }
+        }
+    }
+    #endif
 
-	return hit;
+    return hit;
 }
 
 #endif // INCLUDE_LIGHTING_SSRT

--- a/shaders/lib/lighting/SSRT_HiZ.glsl
+++ b/shaders/lib/lighting/SSRT_HiZ.glsl
@@ -1,0 +1,80 @@
+// Reference:
+// Yasin Uludag, "Hi-Z Screen-Space Cone-Traced Reflection". GPU Pro 5, 2014.
+
+#if !defined INCLUDE_LIGHTING_SSRT_HIZ
+#define INCLUDE_LIGHTING_SSRT_HIZ
+
+// 2-level Hi-Z: level 0 = half-res min-depth, level 1 = full-res depth check
+#define HIZ_MAX_LEVEL 1
+
+float SampleHiZ(ivec2 texel) {
+    return texelFetch(colortex5, texel >> 1, 0).r;
+}
+
+bool HiZRaytrace(vec3 viewOrigin, vec3 viewDir, float dither, uint steps, inout vec3 hitPos) {
+    float maxDist = step(viewDir.z, 0.0) * 1e23 - (viewOrigin.z + near) / viewDir.z;
+    vec3 rayEnd = viewOrigin + viewDir * maxDist;
+
+    vec3 rayOrigin = ViewToScreenPos(viewOrigin);
+    vec3 rayDir = ViewToScreenPos(rayEnd) - rayOrigin;
+    float totalDist = length(rayDir.xy);
+    rayDir /= max(totalDist, 1e-6);
+
+    float rSteps = 1.0 / float(steps);
+    vec3 rayStep = rayDir * rSteps;
+    float invDirZ = rcp(max(abs(rayStep.z), 1e-6));
+
+    float compareTolerance = 2.0 * max(abs(rayStep.z), (rayOrigin.z + gbufferProjection[2].z) * rSteps);
+
+    float t = dither;
+    bool hit = false;
+
+    for (uint i = 0u; i < steps; ++i) {
+        hitPos = rayOrigin + rayStep * t;
+
+        if (saturate(hitPos.xy) != hitPos.xy) break;
+
+        // Coarse check: skip entire 2x2 block if ray is in front
+        ivec2 coarseTexel = ivec2(hitPos.xy * vec2(viewWidth, viewHeight) * 0.5);
+        float minDepth = SampleHiZ(coarseTexel);
+
+        if (hitPos.z < minDepth - 0.001) {
+            // Ray is in front of the entire 2x2 block, skip ahead
+            float skipAmount = (minDepth - hitPos.z) * invDirZ * 0.5;
+            t += max(skipAmount, 0.01);
+            continue;
+        }
+
+        // Fine check: test against actual depth
+        ivec2 sampleTexel = uvToTexelScaled(hitPos.xy);
+        float sampleDepth = loadDepth2(sampleTexel);
+
+        float depthDiff = sampleDepth - hitPos.z;
+        if (abs(depthDiff + compareTolerance) < compareTolerance) {
+            hit = true;
+            break;
+        }
+
+        t += clamp(depthDiff * invDirZ, 0.01, 1.1);
+    }
+
+#ifdef SSRT_REFINEMENT
+    if (hit) {
+        for (uint i = 0u; i < SSRT_REFINEMENT_STEPS; ++i) {
+            rayStep *= 0.5;
+            ivec2 sampleTexel = uvToTexelScaled(hitPos.xy);
+            float sampleDepth = loadDepth2(sampleTexel);
+            float depthDiff = sampleDepth - hitPos.z;
+            if (abs(depthDiff + compareTolerance) < compareTolerance) {
+                hitPos -= rayStep;
+            } else {
+                hitPos += rayStep;
+            }
+        }
+    }
+#endif
+
+    return hit;
+}
+
+#endif

--- a/shaders/lib/universal/Random.glsl
+++ b/shaders/lib/universal/Random.glsl
@@ -85,25 +85,6 @@ uint triple32(uint x) {
 	return x;
 }
 
-// https://www.pcg-random.org/
-uint pcg(inout uint state) {
-    state = state * 747796405u + 2891336453u;
-    uint result = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
-    return (result >> 22u) ^ result;
-}
-
-float nextFloat(inout uint state) {
-    return float(pcg(state)) * rcp(4294967295.0);
-}
-
-vec2 nextVec2(inout uint state) {
-    return vec2(nextFloat(state), nextFloat(state));
-}
-
-uint initRandomState(uvec2 texelIndex, uint frameIndex) {
-	return triple32(EncodeMorton2D(texelIndex)) + frameIndex;
-}
-
 //================================================================================================//
 
 // Rn sequence from http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
@@ -179,6 +160,21 @@ vec2 SampleStbnUnitvec2(ivec2 texel, int frame) {
 
 //================================================================================================//
 
+// Bayer Dithering
+float bayer2(vec2 a) {
+	a = floor(a);
+	return fract(dot(a, vec2(0.5, a.y * 0.75)));
+}
+
+float bayer4(vec2 a)   { return bayer2 (0.5 * a) * 0.25 + bayer2(a); }
+float bayer8(vec2 a)   { return bayer4 (0.5 * a) * 0.25 + bayer2(a); }
+float bayer16(vec2 a)  { return bayer8 (0.5 * a) * 0.25 + bayer2(a); }
+float bayer32(vec2 a)  { return bayer16(0.5 * a) * 0.25 + bayer2(a); }
+float bayer64(vec2 a)  { return bayer32(0.5 * a) * 0.25 + bayer2(a); }
+float bayer128(vec2 a) { return bayer64(0.5 * a) * 0.25 + bayer2(a); }
+
+//================================================================================================//
+
 // Interleaved Gradient Noise
 // https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare/
 // https://blog.demofox.org/2022/01/01/interleaved-gradient-noise-a-different-kind-of-low-discrepancy-sequence/
@@ -220,6 +216,110 @@ float dither256x256(uvec2 fragCoord) {
     return uintBitsToFloat(
         floatBitsToUint(1.0) | z
     ) - 1.0;
+}
+
+//================================================================================================//
+
+/***************************************************************************
+# Copyright (c) 2015-21, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**************************************************************************/
+
+/** Utility functions for Morton codes.
+	This is using the usual bit twiddling. See e.g.: https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/
+
+	The interleave functions are named based to their output size in bits.
+	The deinterleave functions are named based on their input size in bits.
+	So, deinterleave_16bit(interleave_16bit(x)) == x should hold true.
+
+	TODO: Make this a host/device shared header, ensure code compiles on the host.
+	TODO: Add optimized 8-bit and 2x8-bit interleaving functions.
+	TODO: Use NvApi intrinsics to optimize the code on NV.
+*/
+
+/** 32-bit bit interleave (Morton code).
+	\param[in] v 16-bit values in the LSBs of each component (higher bits don't matter).
+	\return 32-bit value.
+*/
+uint interleave_32bit(uvec2 v) {
+	uint x = v.x & 0x0000ffffu;              // x = ---- ---- ---- ---- fedc ba98 7654 3210
+	uint y = v.y & 0x0000ffffu;
+
+	x = (x | (x << 8)) & 0x00FF00FFu;        // x = ---- ---- fedc ba98 ---- ---- 7654 3210
+	x = (x | (x << 4)) & 0x0F0F0F0Fu;        // x = ---- fedc ---- ba98 ---- 7654 ---- 3210
+	x = (x | (x << 2)) & 0x33333333u;        // x = --fe --dc --ba --98 --76 --54 --32 --10
+	x = (x | (x << 1)) & 0x55555555u;        // x = -f-e -d-c -b-a -9-8 -7-6 -5-4 -3-2 -1-0
+
+	y = (y | (y << 8)) & 0x00FF00FFu;
+	y = (y | (y << 4)) & 0x0F0F0F0Fu;
+	y = (y | (y << 2)) & 0x33333333u;
+	y = (y | (y << 1)) & 0x55555555u;
+
+	return x | (y << 1);
+}
+
+/** Generates a pair of 32-bit pseudorandom numbers based on a pair of 32-bit values.
+
+	The code uses a 64-bit block cipher, the Tiny Encryption Algorithm (TEA) by Wheeler et al., 1994.
+	The 128-bit key is fixed and adapted from here: https://www.ibiblio.org/e-notes/webcl/mc.htm.
+	This function can be useful for seeding other pseudorandom number generators.
+
+	\param[in] v0 The first value (low dword of the block).
+	\param[in] v1 The second value (high dword of the block).
+	\param[in] iterations Number of iterations (the authors recommend 16 at a minimum).
+	\return Two pseudorandom numbers (the block cipher of (v0,v1)).
+*/
+uvec2 blockCipherTEA(uint v0, uint v1) {
+	uint sum = 0u;
+	const uint delta = 0x9e3779b9u;
+	const uint k[4] = uint[4](0xa341316cu, 0xc8013ea4u, 0xad90777du, 0x7e95761eu); // 128-bit key.
+	for (uint i = 0u; i < 16u; ++i) {
+		sum += delta;
+		v0 += ((v1 << 4) + k[0]) ^ (v1 + sum) ^ ((v1 >> 5) + k[1]);
+		v1 += ((v0 << 4) + k[2]) ^ (v0 + sum) ^ ((v0 >> 5) + k[3]);
+	}
+	return uvec2(v0, v1);
+}
+
+float nextFloat(inout uint currentNum) {
+	const uint A = 1664525u;
+	const uint C = 1013904223u;
+	currentNum = (A * currentNum + C);
+	return float(currentNum >> 8) * rcp(16777216.0);
+}
+
+vec2 nextVec2(inout uint currentNum) {
+	vec2 noise;
+	noise.x = nextFloat(currentNum);
+	noise.y = nextFloat(currentNum);
+	return noise;
+}
+
+uint initNoiseGenerator(uvec2 texelIndex, uint frameIndex) {
+	return blockCipherTEA(interleave_32bit(texelIndex), frameIndex).x;
 }
 
 //================================================================================================//

--- a/shaders/lib/utility/Pack.glsl
+++ b/shaders/lib/utility/Pack.glsl
@@ -69,25 +69,6 @@ vec3 OctDecodeUnorm(vec2 oct) {
 	return OctDecodeSnorm(oct * 2.0 - 1.0);
 }
 
-// https://github.com/liamdon/fast-morton
-uint EncodeMorton2D(uvec2 xy) {
-    xy &= 0x0000FFFFu;
-    xy = (xy | (xy << 8)) & 0x00FF00FFu;
-    xy = (xy | (xy << 4)) & 0x0F0F0F0Fu;
-    xy = (xy | (xy << 2)) & 0x33333333u;
-    xy = (xy | (xy << 1)) & 0x55555555u;
-    return xy.x | (xy.y << 1);
-}
-
-uint EncodeMorton3D(uvec3 xyz) {
-    xyz &= 0x000003FFu;
-    xyz = (xyz | (xyz << 16)) & 0x030000FFu;
-    xyz = (xyz | (xyz <<  8)) & 0x0300F00Fu;
-    xyz = (xyz | (xyz <<  4)) & 0x030C30C3u;
-    xyz = (xyz | (xyz <<  2)) & 0x09249249u;
-    return xyz.x | (xyz.y << 1) | (xyz.z << 2);
-}
-
 // Mercator projection
 vec2 ProjectMercator(vec3 dir) {
 	float phi = atan(dir.x, dir.z); // Longitude

--- a/shaders/program/CombineLighting.frag
+++ b/shaders/program/CombineLighting.frag
@@ -137,6 +137,10 @@ void main() {
 
 			sceneOut += celestial * transmittance;
 		}
+	} else if (materialID >= 500u && materialID < 1000u) {
+		// Translucent entities/blocks/particles - skip PBR, handled by Translucent.comp
+		// sceneOut is already vec3(0.0) from initialization
+		return;
 	} else {
 		vec3 screenPos = vec3(screenCoord, loadDepth0(texelPos));
         #ifdef PARALLAX_SHADOW

--- a/shaders/program/IntegrateScene.frag
+++ b/shaders/program/IntegrateScene.frag
@@ -141,6 +141,8 @@ void main() {
 	uint materialID = materialPack.y;
 	bool glassMask = materialID == 2u;
 	bool waterMask = materialID == 3u;
+	bool isGlassOrWater = glassMask || waterMask;
+	bool isTranslucentGeneric = materialID >= 500u && materialID < 1000u;
 
 	// Process refraction
 	ivec2 refractedTexel = texelPos;
@@ -159,14 +161,20 @@ void main() {
 		vec4 translucentColor = loadAlbedo(texelPos);
 		vec3 albedo = sRGBToLinear(translucentColor.rgb) * sRGB_2_Rec2020;
 
-		// Particle translucent
-		if (materialID == 500u) {
+		// Generic translucent blending (particles, entities, blocks, text, etc.)
+		if (isTranslucentGeneric) {
 			vec3 diffuseLight = texelFetch(colortex3, texelPos, 0).rgb;
 			sceneColor = mix(sceneColor, albedo * diffuseLight, translucentColor.a);
 		}
 
-		// Translucent
-		if (glassMask || waterMask) {
+		// Emissive translucent (spider eyes, enderman eyes, etc.)
+		if (materialID == 20u) {
+			vec3 emissive = albedo * Unpack2x8UX(materialPack.x) * (2.0 * EMISSIVE_BRIGHTNESS);
+			sceneColor = mix(sceneColor, sceneColor + emissive, translucentColor.a);
+		}
+
+		// Translucent (water/glass with special handling)
+		if (isGlassOrWater) {
 			if (glassMask) {
 				// Absorption
 				sceneColor *= exp2(log2(albedo * oms(0.125 * translucentColor.a)) * approxSqrt(translucentColor.a + 0.25));

--- a/shaders/program/Translucent.comp
+++ b/shaders/program/Translucent.comp
@@ -81,13 +81,16 @@ vec4 CalculateSpecularReflections(vec3 screenPos, vec3 viewPos, vec3 worldNormal
 void main() {
 	ivec2 texelPos = ivec2(gl_GlobalInvocationID.xy);
 
-	uvec2 materialPack = loadMaterialPack(texelPos).xy;
+	uvec4 materialPack = loadMaterialPack(texelPos);
 
 	uint materialID = materialPack.y;
-	bool notParticle = materialID != 500u;
+	bool isParticle = materialID == 500u;
+	bool isWaterGlass = clamp(materialID, 2u, 3u) == materialID;
+	bool isTranslucentEntity = materialID >= 500u && materialID < 1000u;
+	bool isTranslucent = isWaterGlass || isTranslucentEntity;
 
 	// Skip opaque fragments
-	if (clamp(materialID, 2u, 3u) != materialID && notParticle) return;
+	if (!isTranslucent) return;
 
 	vec3 screenPos = vec3(texelToUvScaled(texelPos), loadDepth0(texelPos));
 	#if defined LOD_MOD
@@ -162,9 +165,15 @@ void main() {
 
 	float NdotL = 1.0;
 
-	if (notParticle) {
-		// Specular indirect
-		lightingOut = CalculateSpecularReflections(screenPos, viewPos, worldNormal, worldDir, dither, lightmap.y, waterMask);
+	if (!isParticle) {
+		// Specular indirect - only water/glass gets reflections
+		if (isWaterGlass) {
+			lightingOut = CalculateSpecularReflections(screenPos, viewPos, worldNormal, worldDir, dither, lightmap.y, waterMask);
+		} else {
+			// Entity/block translucent: ambient base
+			lightingOut.rgb = global.skyUpIlluminance * cube(lightmap.y);
+			lightingOut.rgb += CalculateBlocklightFalloff(lightmap.x) * blocklightColor;
+		}
 
 		NdotL = dot(worldNormal, shadowDirWorld);
 	} else {
@@ -191,24 +200,30 @@ void main() {
 		vec3 shadow = CalculatePCSS(worldPos, normalOffset, dither, surfaceDepth);
 
 		if (dot(shadow, vec3(1.0)) > EPS) {
-			shadow = saturate(shadow) * sunlightMult;
+		shadow = saturate(shadow) * sunlightMult;
 
-			if (notParticle) {
+		if (!isParticle) {
 				float NdotV = -dot(worldNormal, worldDir);
 			    float LdotV = -dot(shadowDirWorld, worldDir);
 
-                float invLenH = inversesqrt(2.0 + 2.0 * LdotV);
-                float NdotH = saturate((NdotL + NdotV) * invLenH);
-                float VdotH = saturate(LdotV * invLenH + invLenH);
-                NdotL = saturate(NdotL);
-                NdotV = saturate(NdotV);
+	            float invLenH = inversesqrt(2.0 + 2.0 * LdotV);
+	            float NdotH = saturate((NdotL + NdotV) * invLenH);
+	            float VdotH = saturate(LdotV * invLenH + invLenH);
+	            NdotL = saturate(NdotL);
+	            NdotV = saturate(NdotV);
 
-				float f0 = F0FromIOR(waterMask ? WATER_IOR : GLASS_IOR);
-				lightingOut.rgb += shadow * SpecularGGX(VdotH, NdotV, NdotL, NdotH, TRANSLUCENT_ROUGHNESS, vec3(f0));
+				if (isWaterGlass) {
+					float f0 = F0FromIOR(waterMask ? WATER_IOR : GLASS_IOR);
+					lightingOut.rgb += shadow * SpecularGGX(VdotH, NdotV, NdotL, NdotH, TRANSLUCENT_ROUGHNESS, vec3(f0));
+				} else {
+					vec4 specularTex = ExtractSpecularTex(materialPack);
+					float roughness = sqr(1.0 - specularTex.r);
+					lightingOut.rgb += shadow * (rPI + SpecularGGX(VdotH, NdotV, NdotL, NdotH, max(roughness, 0.04), vec3(DEFAULT_DIELECTRIC_F0)));
+				}
 			} else {
 				lightingOut.rgb += shadow * rPI;
 			}
-		}
+	}
 	}
 
 	imageStore(colorimg3, texelPos, lightingOut);

--- a/shaders/program/diffuse/EAWF.comp
+++ b/shaders/program/diffuse/EAWF.comp
@@ -95,7 +95,7 @@ void main() {
 	uvec2 localPos = RemapThread16x16(gl_LocalInvocationIndex);
 	ivec2 texelPos = ivec2(localPos + gl_WorkGroupID.xy * gl_WorkGroupSize.xy);
 
-	vec3 normalDepthData = texelFetch(colortex14, texelPos, 0).rgb;
+	f16vec3 normalDepthData = f16vec3(texelFetch(colortex14, texelPos, 0).rgb);
 	// vec2 depthGradient = vec2(dFdx(normalDepthData.w), dFdy(normalDepthData.w));
 
 	// 0.0625 0.125 0.0625
@@ -105,8 +105,8 @@ void main() {
 
 	const float kernel[8] = {0.0625, 0.125, 0.0625, 0.125, 0.125, 0.0625, 0.125, 0.0625};
 
-	vec4 filteredColVar = imageLoad(colorimg3, texelPos);
-	float centerLuma = filteredColVar.r; // We use YCoCg color space
+	f16vec4 filteredColVar = f16vec4(imageLoad(colorimg3, texelPos));
+	float16_t centerLuma = filteredColVar.r; // We use YCoCg color space
 
 	float frameIndex = texelFetch(colortex2, texelPos, 0).a;
 	float historyFactor = saturate(frameIndex * 0.1 - 0.125);
@@ -120,36 +120,36 @@ void main() {
 	float invThresholdZ = 8.0 / normalDepthData.z;
 
 	// float variance = CalculateVariance(ivec2(localPos + padRadius));
-	float variance = filteredColVar.a;
+	float16_t variance = filteredColVar.a;
 	float sigmaL = -0.5 * inversesqrt(variance + EPS) * historyFactor;
 	float sigmaN = 32.0 * exp2(-0.5 * variance / sqr(centerLuma)) * historyFactor;
 
-	vec3 centerNormal = OctDecodeSnorm(normalDepthData.xy);
+	f16vec3 centerNormal = f16vec3(OctDecodeSnorm(normalDepthData.xy));
 
-	float sumWeight = 1.0;
+	float16_t sumWeight = float16_t(1.0);
 	// filteredColVar *= vec4(vec3(sumWeight), sumWeight * sumWeight);
 	vec2 sampleTexelBase = vec2(texelPos) + (BlueNoise(texelPos, frameCounter + FILTER_PASS_INDEX) - 0.5) * offsetScale;
 
 	for (uint i = 0u; i < 9u; ++i) {
 		ivec2 sampleTexel = ivec2(round(sampleTexelBase + offset3x3[i] * offsetScale));
 		if (clamp(sampleTexel, ivec2(1), ivec2(scaledHalfViewSize) - 2) == sampleTexel) {
-			vec3 sampleAux = texelFetch(colortex14, sampleTexel, 0).rgb;
+			f16vec3 sampleAux = f16vec3(texelFetch(colortex14, sampleTexel, 0).rgb);
 
-			vec4 sampleColVar = imageLoad(colorimg3, sampleTexel);
-			float sampleLuma = sampleColVar.r; // We use YCoCg color space
+			f16vec4 sampleColVar = f16vec4(imageLoad(colorimg3, sampleTexel));
+			float16_t sampleLuma = sampleColVar.r; // We use YCoCg color space
 
-			float weight = saturate(fma(abs(sampleAux.z - normalDepthData.z), invThresholdZ, 1.0));
+			float16_t weight = float16_t(saturate(fma(abs(sampleAux.z - normalDepthData.z), invThresholdZ, 1.0)));
 
 			float logWeightN = log2(saturate(dot(OctDecodeSnorm(sampleAux.xy), centerNormal))) * sigmaN;
 			float logWeightL = abs(sampleLuma - centerLuma) * sigmaL;
-			weight *= saturate(exp2(logWeightN + logWeightL));
+			weight *= float16_t(saturate(exp2(logWeightN + logWeightL)));
 
-			filteredColVar += sampleColVar * vec4(vec3(weight), weight * weight);
+			filteredColVar += sampleColVar * f16vec4(f16vec3(weight), weight * weight);
 			sumWeight += weight;
 		}
 	}
 
-	sumWeight = 1.0 / sumWeight;
-	filteredColVar *= vec4(vec3(sumWeight), sumWeight * sumWeight);
+	sumWeight = float16_t(1.0) / sumWeight;
+	filteredColVar *= f16vec4(f16vec3(sumWeight), sumWeight * sumWeight);
 	imageStore(colorimg3, texelPos, min(filteredColVar, FP16_MAX));
 }

--- a/shaders/program/gbuffers/BlockTrans.frag
+++ b/shaders/program/gbuffers/BlockTrans.frag
@@ -1,0 +1,175 @@
+/*
+--------------------------------------------------------------------------------
+
+	Revelation Shaders
+
+	Copyright (C) 2026 HaringPro
+	Apache License 2.0
+
+--------------------------------------------------------------------------------
+*/
+
+//======// Utility //=============================================================================//
+
+#include "/lib/Utility.glsl"
+
+//======// Output //==============================================================================//
+
+/* RENDERTARGETS: 6,7,8 */
+layout(location = 0) out vec4 albedoOut;
+layout(location = 1) out uvec4 materialOut;
+layout(location = 2) out vec4 normalOut;
+
+#if defined PARALLAX && defined PARALLAX_SHADOW
+/* RENDERTARGETS: 6,7,8,12 */
+layout(location = 3) out float parallaxOffsetOut;
+#endif
+
+//======// Input //===============================================================================//
+
+in vec4 vertColor;
+in vec2 texCoord;
+in vec2 lightmap;
+flat in uint materialID;
+
+in vec3 worldPos;
+
+//======// Uniform //=============================================================================//
+
+uniform sampler2D tex;
+uniform sampler2D normals;
+uniform sampler2D specular;
+
+#include "/lib/universal/Uniform.glsl"
+
+//======// Function //============================================================================//
+
+#include "/lib/universal/Random.glsl"
+
+// Thanks to GeForceLegend
+const vec3[] COLORS = vec3[](
+	vec3(0.022087, 0.098399, 0.110818),
+	vec3(0.011892, 0.095924, 0.089485),
+	vec3(0.027636, 0.101689, 0.100326),
+	vec3(0.046564, 0.109883, 0.114838),
+	vec3(0.064901, 0.117696, 0.097189),
+	vec3(0.063761, 0.086895, 0.123646),
+	vec3(0.084817, 0.111994, 0.166380),
+	vec3(0.097489, 0.154120, 0.091064),
+	vec3(0.106152, 0.131144, 0.195191),
+	vec3(0.097721, 0.110188, 0.187229),
+	vec3(0.133516, 0.138278, 0.148582),
+	vec3(0.070006, 0.243332, 0.235792),
+	vec3(0.196766, 0.142899, 0.214696),
+	vec3(0.047281, 0.315338, 0.321970),
+	vec3(0.204675, 0.390010, 0.302066),
+	vec3(0.080955, 0.314821, 0.661491)
+);
+
+vec2 endPortalLayer(vec2 coord, float layer) {
+	vec2 offset = vec2(8.5 / layer, (1.0 + layer / 3.0) * (frameTimeCounter * 0.0015)) + 0.25;
+
+	mat2 rotate = rotateMat(radians(layer * layer * 8642.0 + layer * 18.0));
+
+	return (4.5 - layer * 0.25) * (rotate * coord) + offset;
+}
+
+#ifdef RAIN_PUDDLES
+	#include "/lib/surface/RainPuddle.glsl"
+#endif
+
+//======// Main //================================================================================//
+void main() {
+    #if (RENDER_SCALE_1000X != 1000) || SR_ENABLE
+        if (any(greaterThanEqual(gl_FragCoord.xy, scaledViewSize))) {
+            discard;
+        }
+    #endif
+
+    vec2 deltaUv1 = dFdx(texCoord);
+    vec2 deltaUv2 = dFdy(texCoord);
+
+	vec3 deltaPos1 = dFdx(worldPos);
+	vec3 deltaPos2 = dFdy(worldPos);
+
+	vec3 geoNormal = normalize(cross(deltaPos1, deltaPos2));
+
+	// Construct TBN matrix
+	#ifdef MC_NORMAL_MAP
+
+        vec3 tangentPerp = deltaPos2 * deltaUv1.x - deltaPos1 * deltaUv2.x;
+        vec3 tangent = normalize(cross(tangentPerp, geoNormal));
+
+        vec3 bitangentPerp = deltaPos2 * deltaUv1.y - deltaPos1 * deltaUv2.y;
+        vec3 bitangent = normalize(cross(bitangentPerp, geoNormal));
+
+		mat3 tbnMatrix = mat3(tangent, bitangent, geoNormal);
+	#endif
+
+    // Increase detail reserve
+    deltaUv1 *= 0.5;
+    deltaUv2 *= 0.5;
+
+	vec4 albedo = textureGrad(tex, texCoord, deltaUv1, deltaUv2) * vertColor;
+
+	if (albedo.a < alphaTestRef) discard;
+
+	#ifdef WHITE_WORLD
+		albedo.rgb = vec3(1.0);
+	#endif
+
+	#if defined MC_NORMAL_MAP
+		vec3 normalTex = textureGrad(normals, texCoord, deltaUv1, deltaUv2).rgb;
+		DecodeNormalTex(normalTex);
+		vec3 normal = tbnMatrix * normalTex;
+	#else
+		vec3 normal = geoNormal;
+	#endif
+
+	#if defined PARALLAX && defined PARALLAX_SHADOW
+		parallaxOffsetOut = 0.0;
+	#endif
+
+	#if defined MC_SPECULAR_MAP
+		vec4 specularTex = textureGrad(specular, texCoord, deltaUv1, deltaUv2);
+	#else
+		vec4 specularTex = vec4(0.0);
+	#endif
+
+    // Render end portal
+	if (materialID == 546u) {
+		vec3 worldDir = normalize(worldPos);
+		vec3 worldDirAbs = abs(worldDir);
+		vec3 sampleMask = step(maxOf(worldDirAbs), worldDirAbs);
+		vec3 samplePart = signMul(sampleMask, worldDir);
+		float intersection = 1.0 / dot(sampleMask, worldDirAbs);
+		vec3 sampleNDCRaw = samplePart - worldDir * intersection;
+		vec2 sampleNDC = sampleNDCRaw.xy * vec2(sampleMask.y + samplePart.z, 1.0 - sampleMask.y) + sampleNDCRaw.z * vec2(-samplePart.x, sampleMask.y);
+		vec2 portalCoord = sampleNDC * 0.5 + 0.5;
+
+		vec3 portalColor = vec3(0.0);
+		for (uint i = 0u; i < 16u; ++i) {
+			portalColor += textureGrad(tex, endPortalLayer(portalCoord, float(i + 1)), deltaUv1, deltaUv2).rgb * COLORS[i];
+		}
+		albedo.rgb = portalColor;
+		specularTex = vec4(1.0, 0.0, vec2(254.0 / 255.0));
+	}
+
+	albedoOut = albedo;
+
+	materialOut.x = Pack2x8U(lightmap, BlueNoise(ivec2(gl_FragCoord.xy), frameCounter + 1));
+	materialOut.y = materialID;
+
+	// Compute rain puddles
+	#ifdef RAIN_PUDDLES
+		if (wetnessCustom > EPS) {
+			ApplyRainPuddleMaterial(albedoOut.rgb, specularTex.rgb, worldPos, normal, geoNormal, lightmap.y);
+		}
+	#endif
+
+	normalOut.xy = OctEncodeSnorm(geoNormal);
+	normalOut.zw = OctEncodeSnorm(normal);
+
+	materialOut.z = Pack2x8U(specularTex.xy);
+	materialOut.w = Pack2x8U(specularTex.zw);
+}

--- a/shaders/program/gbuffers/BlockTrans.vert
+++ b/shaders/program/gbuffers/BlockTrans.vert
@@ -15,16 +15,12 @@
 
 //======// Output //==============================================================================//
 
-#if defined MC_NORMAL_MAP
-	out mat3 tbnMatrix;
-#else
-	out vec3 geoNormal;
-#endif
-
 out vec4 vertColor;
 out vec2 texCoord;
 out vec2 lightmap;
 flat out uint materialID;
+
+out vec3 worldPos;
 
 //======// Attribute //===========================================================================//
 
@@ -32,8 +28,9 @@ in vec4 at_tangent;
 
 //======// Uniform //=============================================================================//
 
-uniform int entityId;
+uniform int blockEntityId;
 
+uniform mat4 gbufferModelView;
 uniform mat4 gbufferModelViewInverse;
 
 uniform vec2 taaJitter;
@@ -41,20 +38,16 @@ uniform vec2 renderScale;
 
 //======// Main //================================================================================//
 void main() {
-	#if 0
-	// Kill the nametag
-	if (clamp(gl_Color.a, 0.24, 0.254) == gl_Color.a) {
-		gl_Position = vec4(-1.0);
-		return;
-	}
-	#endif
-
 	vertColor = gl_Color;
 	texCoord = vec2(gl_TextureMatrix[0] * gl_MultiTexCoord0);
 
 	lightmap = saturate((gl_MultiTexCoord1.xy - 8.0) * rcp(232.0));
 
+	materialID = blockEntityId < 10000 ? 502u : uint(blockEntityId - 10000 + 500);
+
 	vec3 viewPos = transMAD(gl_ModelViewMatrix, gl_Vertex.xyz);
+	worldPos = transMAD(gbufferModelViewInverse, viewPos);
+
     gl_Position = project(gl_ProjectionMatrix, viewPos);
     #ifdef SHOULD_APPLY_JITTER
         gl_Position.xy += taaJitter * gl_Position.w;
@@ -62,16 +55,4 @@ void main() {
     #if (RENDER_SCALE_1000X != 1000) || SR_ENABLE
         gl_Position.xy = gl_Position.xy * renderScale + (renderScale - 1.0) * gl_Position.w;
     #endif
-
-	#if defined MC_NORMAL_MAP
-		tbnMatrix[2] = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * gl_Normal);
-		tbnMatrix[0] = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * at_tangent.xyz);
-		tbnMatrix[1] = signMul(cross(tbnMatrix[0], tbnMatrix[2]), at_tangent.w);
-	#else
-		geoNormal = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * gl_Normal);
-	#endif
-
-	// 829925: Physics mod snow
-	// Handle default case when entityId is -1 (not mapped in entity.properties)
-	materialID = entityId == 829925 ? 39u : (entityId < 10000 ? 1u : uint(entityId - 10000));
 }

--- a/shaders/program/gbuffers/EntitiesTrans.frag
+++ b/shaders/program/gbuffers/EntitiesTrans.frag
@@ -1,0 +1,108 @@
+/*
+--------------------------------------------------------------------------------
+
+	Revelation Shaders
+
+	Copyright (C) 2026 HaringPro
+	Apache License 2.0
+
+--------------------------------------------------------------------------------
+*/
+
+//======// Utility //=============================================================================//
+
+#include "/lib/Utility.glsl"
+
+//======// Output //==============================================================================//
+
+/* RENDERTARGETS: 6,7,8 */
+layout(location = 0) out vec4 albedoOut;
+layout(location = 1) out uvec4 materialOut;
+layout(location = 2) out vec4 normalOut;
+
+#if defined PARALLAX && defined PARALLAX_SHADOW
+/* RENDERTARGETS: 6,7,8,12 */
+layout(location = 3) out float parallaxOffsetOut;
+#endif
+
+//======// Uniform //=============================================================================//
+
+uniform sampler2D tex;
+uniform sampler2D normals;
+uniform sampler2D specular;
+
+uniform vec4 entityColor;
+
+uniform float alphaTestRef;
+
+uniform vec2 scaledViewSize;
+
+//======// Input //===============================================================================//
+
+#if defined MC_NORMAL_MAP
+	in mat3 tbnMatrix;
+	#define geoNormal tbnMatrix[2]
+#else
+	in vec3 geoNormal;
+#endif
+
+in vec4 vertColor;
+in vec2 texCoord;
+in vec2 lightmap;
+flat in uint materialID;
+
+//======// Main //================================================================================//
+void main() {
+    #if (RENDER_SCALE_1000X != 1000) || SR_ENABLE
+        if (any(greaterThanEqual(gl_FragCoord.xy, scaledViewSize))) {
+            discard;
+        }
+    #endif
+
+    vec2 deltaUv1 = dFdx(texCoord);
+    vec2 deltaUv2 = dFdy(texCoord);
+
+	#if GBUFFERS_LIGHTNING
+       vec4 albedo = vec4(0.7, 0.675, 1.0, texture(tex, texCoord).a);
+    #else
+        vec4 albedo = textureGrad(tex, texCoord, deltaUv1, deltaUv2) * vertColor;
+        if (albedo.a < alphaTestRef) discard;
+    #endif
+
+	#ifdef WHITE_WORLD
+		albedo.rgb = vec3(1.0);
+	#endif
+
+	albedo.rgb = mix(albedo.rgb, entityColor.rgb, entityColor.a);
+
+	albedoOut = albedo;
+
+	materialOut.x = Pack2x8U(lightmap);
+	#if GBUFFERS_SPIDEREYES
+materialOut.y = 20u;
+#else
+materialOut.y = materialID;
+#endif
+
+	#if defined MC_SPECULAR_MAP
+		vec4 specularTex = textureGrad(specular, texCoord, deltaUv1, deltaUv2);
+		materialOut.z = Pack2x8U(specularTex.xy);
+		materialOut.w = Pack2x8U(specularTex.zw);
+	#else
+		materialOut.zw = uvec2(0);
+	#endif
+
+	normalOut.xy = OctEncodeSnorm(geoNormal);
+
+	#if defined MC_NORMAL_MAP
+		vec3 normalTex = textureGrad(normals, texCoord, deltaUv1, deltaUv2).rgb;
+		DecodeNormalTex(normalTex);
+		normalOut.zw = OctEncodeSnorm(tbnMatrix * normalTex);
+	#else
+		normalOut.zw = normalOut.xy;
+	#endif
+
+	#if defined PARALLAX && defined PARALLAX_SHADOW
+		parallaxOffsetOut = 0.0;
+	#endif
+}

--- a/shaders/program/gbuffers/EntitiesTrans.vert
+++ b/shaders/program/gbuffers/EntitiesTrans.vert
@@ -71,7 +71,7 @@ void main() {
 		geoNormal = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * gl_Normal);
 	#endif
 
+	// Translucent entities offset material ID by 500 to stay in 500-999 range
 	// 829925: Physics mod snow
-	// Handle default case when entityId is -1 (not mapped in entity.properties)
-	materialID = entityId == 829925 ? 39u : (entityId < 10000 ? 1u : uint(entityId - 10000));
+	materialID = entityId == 829925 ? 39u : (entityId < 10000 ? 501u : uint(entityId - 10000 + 500));
 }

--- a/shaders/program/gbuffers/Terrain.vert
+++ b/shaders/program/gbuffers/Terrain.vert
@@ -58,11 +58,12 @@ void main() {
 
 	vec3 worldPos = transMAD(gbufferModelViewInverse, transMAD(gl_ModelViewMatrix, gl_Vertex.xyz));
 
-	materialID = uint(max(mc_Entity.x - 1e4, 1));
+	float rawMaterialID = mc_Entity.x - 1e4;
+	materialID = uint(max(rawMaterialID, 1.0));
 
 	// Unlabelled foilage detection
 	#ifdef UNLABELLED_FOILAGE_DETECTION
-		if (materialID < 1u && maxOf(abs(gl_Normal)) < 0.99) materialID = 1003u;
+		if (rawMaterialID < 1.0 && maxOf(abs(gl_Normal)) < 0.99) materialID = 1003u;
 	#endif
 
 	// Encode normal and tangent

--- a/shaders/program/post/Final.frag
+++ b/shaders/program/post/Final.frag
@@ -151,7 +151,7 @@ void main() {
 	#endif
 
 	#ifndef HDR_ENABLED
-		// Apply dithering to reduce banding artifacts
-		finalOut += (InterleavedGradientNoise(gl_FragCoord.xy) - 0.5) * rcp255;
+		// Apply bayer dithering to reduce banding artifacts
+		finalOut += (bayer16(gl_FragCoord.xy) - 0.5) * rcp255;
 	#endif
 }

--- a/shaders/program/post/Grade.frag
+++ b/shaders/program/post/Grade.frag
@@ -15,8 +15,8 @@
 
 #include "/lib/Utility.glsl"
 
-#define TONE_MAPPER 1 // [0 1 2 3 16 17 32 33 48]
-#define HDR_TONE_MAPPER 33 // [0 3 16 17 32 33]
+#define TONE_MAPPER 17 // [0 1 2 3 16 17 32 33 48]
+#define HDR_TONE_MAPPER 17 // [0 3 16 17 32 33]
 
 // 0: disables gamut compression, 1: Rec.2020, 2: P3-D65
 #define ACES_HDR_TARGET_GAMUT 1 // [0 1 2]

--- a/shaders/program/prepare/DepthPyramid.comp
+++ b/shaders/program/prepare/DepthPyramid.comp
@@ -1,0 +1,36 @@
+/*
+--------------------------------------------------------------------------------
+
+    Revelation Shaders
+
+    Copyright (C) 2026 HaringPro
+    Apache License 2.0
+
+    Pass: Generate Hi-Z depth pyramid for SSRT acceleration
+
+--------------------------------------------------------------------------------
+*/
+
+#include "/lib/Utility.glsl"
+
+layout(local_size_x = 16, local_size_y = 16) in;
+const vec2 workGroupsRender = vec2(RENDER_SCALE, RENDER_SCALE);
+
+writeonly uniform image2D colorimg5;
+
+#include "/lib/universal/Uniform.glsl"
+#include "/lib/universal/Transform.glsl"
+#include "/lib/universal/Fetch.glsl"
+
+void main() {
+    uvec2 localPos = RemapThread16x16(gl_LocalInvocationIndex);
+    ivec2 texelPos = ivec2(localPos + gl_WorkGroupID.xy * gl_WorkGroupSize.xy);
+
+    // Level 0: copy depth, min of 2x2
+    float d00 = loadDepth0(texelPos * 2 + ivec2(0, 0));
+    float d10 = loadDepth0(texelPos * 2 + ivec2(1, 0));
+    float d01 = loadDepth0(texelPos * 2 + ivec2(0, 1));
+    float d11 = loadDepth0(texelPos * 2 + ivec2(1, 1));
+    float minDepth = min(min(d00, d10), min(d01, d11));
+    imageStore(colorimg5, texelPos, vec4(minDepth, 0.0, 0.0, 0.0));
+}

--- a/shaders/settings.glsl
+++ b/shaders/settings.glsl
@@ -192,6 +192,12 @@ const float realShadowMapRes = float(shadowMapResolution) * MC_SHADOW_QUALITY;
 
 	#define REFLECTION_FILTER
 
+/* SSRT Optimizations */
+	#define SSRT_HIZ
+	#define SSRT_TEMPORAL
+	#define SSRT_MIPMAP_ROUGH
+	#define SSRT_EDGE_FADE 0.5 // [0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0]
+
 	#if RENDER_MODE == 0
 		#undef REFLECTION_FILTER
 	#endif

--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -55,7 +55,7 @@ screen.Lighting = [Shadows] [GlobalIllumination] [Reflections] [AmbientOcclusion
 
 	screen.Shadows = PCSS_SEARCH_SAMPLES PCSS_FILTER_SAMPLES shadowMapResolution shadowDistance <empty> <empty> COLORED_SHADOWS SCREEN_SPACE_SHADOWS SHADOW_BACKFACE_CULLING SCREEN_SPACE_SHADOWS_SAMPLES <empty> <empty> CLOUD_SHADOWS PARALLAX_SHADOW
 
-	screen.Reflections = ROUGH_REFLECTIONS ROUGH_REFLECTIONS_THRESHOLD REFLECTION_FILTER SSRT_REFINEMENT SSRT_MAX_SAMPLES SSRT_REFINEMENT_STEPS <empty> <empty> SSRT_SKY_TRACING SPECULAR_IMPORTANCE_SAMPLING_BIAS
+	screen.Reflections = ROUGH_REFLECTIONS ROUGH_REFLECTIONS_THRESHOLD REFLECTION_FILTER SSRT_REFINEMENT SSRT_MAX_SAMPLES SSRT_REFINEMENT_STEPS SSRT_HIZ SSRT_EDGE_FADE SSRT_MIPMAP_ROUGH SSRT_TEMPORAL SSRT_SKY_TRACING SPECULAR_IMPORTANCE_SAMPLING_BIAS
 
 	screen.Refractions = RAYTRACED_REFRACTION REFRACTION_STRENGTH
 
@@ -255,8 +255,10 @@ blend.gbuffers_armor_glint				= SRC_COLOR ONE ZERO ONE
 blend.gbuffers_basic					= off
 blend.gbuffers_beaconbeam				= off
 blend.gbuffers_block					= off
+blend.gbuffers_block_translucent		= off
 blend.gbuffers_damagedblock				= off
 blend.gbuffers_entities					= off
+blend.gbuffers_entities_translucent		= off
 blend.gbuffers_hand						= off
 blend.gbuffers_hand_water				= off
 blend.gbuffers_skybasic					= off
@@ -427,6 +429,8 @@ program.world0/deferred8.enabled  		= SSILVB_ENABLED && SVGF_ENABLED
 program.world0/deferred9.enabled  		= SSILVB_ENABLED && SVGF_ENABLED
 program.world0/deferred10.enabled  		= SSILVB_ENABLED && SVGF_ENABLED
 
+
+program.world0/depthpyramid.enabled      = SPECULAR_MAPPING && SSRT_HIZ
 program.world0/deferred30.enabled   	= REFLECTION_FILTER && SPECULAR_MAPPING
 program.world0/deferred31.enabled 		= REFLECTION_FILTER && SPECULAR_MAPPING
 program.world0/deferred32.enabled 		= REFLECTION_FILTER && SPECULAR_MAPPING
@@ -477,6 +481,9 @@ program.world0/composite21.enabled  	= false
 # flip.composite4.colortex1 = true
 
 #====# Buffer Sizes #==============================================================================#
+
+# Hi-Z depth pyramid (half res)
+size.buffer.colortex5  = 0.5 0.5
 
 # Cloud history
 size.buffer.colortex9  = RENDER_SCALE RENDER_SCALE

--- a/shaders/world0/gbuffers_block_translucent.fsh
+++ b/shaders/world0/gbuffers_block_translucent.fsh
@@ -1,0 +1,3 @@
+#version 460 compatibility
+
+#include "/program/gbuffers/BlockTrans.frag"

--- a/shaders/world0/gbuffers_block_translucent.vsh
+++ b/shaders/world0/gbuffers_block_translucent.vsh
@@ -1,0 +1,3 @@
+#version 460 compatibility
+
+#include "/program/gbuffers/BlockTrans.vert"

--- a/shaders/world0/gbuffers_entities_translucent.fsh
+++ b/shaders/world0/gbuffers_entities_translucent.fsh
@@ -1,0 +1,3 @@
+#version 460 compatibility
+
+#include "/program/gbuffers/EntitiesTrans.frag"

--- a/shaders/world0/gbuffers_entities_translucent.vsh
+++ b/shaders/world0/gbuffers_entities_translucent.vsh
@@ -1,0 +1,3 @@
+#version 460 compatibility
+
+#include "/program/gbuffers/EntitiesTrans.vert"


### PR DESCRIPTION
我通过修改半透明渲染的相关代码修复了玩家和史莱姆等半透明实体渲染异常的问题
之前是这样的：
<img width="1920" height="1080" alt="bef" src="https://github.com/user-attachments/assets/839416bc-f49c-4353-97d8-ad186f3d64c9" />
我修改后：
<img width="1920" height="1080" alt="aft" src="https://github.com/user-attachments/assets/8715eea3-ad2c-47c9-9b12-4c806839f64e" />
